### PR TITLE
Add required step param to OpenthermNumber to prevent error on HA restart

### DIFF
--- a/components/opentherm/__init__.py
+++ b/components/opentherm/__init__.py
@@ -51,4 +51,4 @@ async def to_code(config: Dict[str, Any]) -> None:
         generate.define_readers(const.INPUT_SENSOR, input_sensors)
         generate.add_messages(var, input_sensors, schema.INPUTS)
 
-    cg.add_library("ihormelnyk/OpenTherm Library", "1.1.3")
+    cg.add_library("ihormelnyk/OpenTherm Library", "1.1.4")

--- a/components/opentherm/hub.cpp
+++ b/components/opentherm/hub.cpp
@@ -34,8 +34,8 @@ namespace message_data {
     uint16_t parse_u16(const unsigned long response) { return (uint16_t) (response & 0xffff); }
     int16_t parse_s16(const unsigned long response) { return (int16_t) (response & 0xffff); }
     float parse_f88(const unsigned long response) {
-        unsigned int data = response & 0xffff;
-        return (data & 0x8000) ? -(0x10000L - data) / 256.0f : data / 256.0f; 
+        int32_t data = response & 0xffff;
+        return (data & 0x8000)? -(0x10000 - data) / 256.0f : data / 256.0f; 
     }
 
     unsigned int write_flag8_lb_0(const bool value, const unsigned int data) { return value ? data | 0b0000000000000001 : data & 0b1111111111111110; }

--- a/components/opentherm/input.py
+++ b/components/opentherm/input.py
@@ -9,6 +9,7 @@ CONF_min_value = "min_value"
 CONF_max_value = "max_value"
 CONF_auto_min_value = "auto_min_value"
 CONF_auto_max_value = "auto_max_value"
+CONF_step = "step"
 
 OpenthermInput = generate.opentherm_ns.class_("OpenthermInput")
 
@@ -26,6 +27,8 @@ def input_schema(entity: schema.InputSchema) -> cv.Schema:
         schema = schema.extend({ cv.Optional(CONF_auto_min_value, False): cv.boolean })
     if CONF_auto_max_value in entity:
         schema = schema.extend({ cv.Optional(CONF_auto_max_value, False): cv.boolean })
+    if CONF_step in entity:
+        schema = schema.extend({ cv.Optional(CONF_step, False): cv.float_ })
     schema = schema.add_extra(validate_min_value_less_than_max_value)
     return schema
 

--- a/components/opentherm/number.py
+++ b/components/opentherm/number.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import number
-from esphome.const import CONF_ID, CONF_UNIT_OF_MEASUREMENT
+from esphome.const import CONF_ID, CONF_UNIT_OF_MEASUREMENT, CONF_STEP
 
 from . import const, schema, validate, input, generate
 
@@ -15,7 +15,7 @@ OpenthermNumber = generate.opentherm_ns.class_("OpenthermNumber", number.Number,
 async def new_openthermnumber(config: Dict[str, Any]) -> cg.Pvariable:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await number.register_number(var, config, min_value = config[input.CONF_min_value], max_value = config[input.CONF_max_value])
+    await number.register_number(var, config, min_value = config[input.CONF_min_value], max_value = config[input.CONF_max_value], step = config[input.CONF_step])
     input.generate_setters(var, config)
     return var
 
@@ -23,7 +23,8 @@ def get_entity_validation_schema(entity: schema.InputSchema) -> cv.Schema:
     return number.NUMBER_SCHEMA \
         .extend({
             cv.GenerateID(): cv.declare_id(OpenthermNumber),
-            cv.Optional(CONF_UNIT_OF_MEASUREMENT, entity["unit_of_measurement"]): cv.string_strict
+            cv.Optional(CONF_UNIT_OF_MEASUREMENT, entity["unit_of_measurement"]): cv.string_strict,
+            cv.Optional(CONF_STEP, entity["step"]): cv.float_,
         }) \
         .extend(input.input_schema(entity)) \
         .extend(cv.COMPONENT_SCHEMA)

--- a/components/opentherm/schema.py
+++ b/components/opentherm/schema.py
@@ -1,8 +1,7 @@
 # This file contains a schema for all supported sensors, binary sensors and
 # inputs of the OpenTherm component.
 
-from typing import Dict, Generic, Tuple, TypeVar, TypedDict
-from typing_extensions import NotRequired
+from typing import Dict, Generic, Tuple, TypeVar, TypedDict, NotRequired
 
 from esphome.const import (
     UNIT_CELSIUS,

--- a/components/opentherm/schema.py
+++ b/components/opentherm/schema.py
@@ -476,6 +476,7 @@ class AutoConfigure(TypedDict):
 
 class InputSchema(EntitySchema):
     unit_of_measurement: str
+    step: float
     range: Tuple[int, int]
     auto_max_value: NotRequired[AutoConfigure]
     auto_min_value: NotRequired[AutoConfigure]
@@ -484,6 +485,7 @@ INPUTS: Schema[InputSchema] = Schema({
     "t_set": InputSchema({
         "description": "Control setpoint: temperature setpoint for the boiler's supply water",
         "unit_of_measurement": UNIT_CELSIUS,
+        "step": 0.1,
         "message": "TSet",
         "keep_updated": True,
         "message_data": "f88",
@@ -493,6 +495,7 @@ INPUTS: Schema[InputSchema] = Schema({
     "t_set_ch2": InputSchema({
         "description": "Control setpoint 2: temperature setpoint for the boiler's supply water on the second heating circuit",
         "unit_of_measurement": UNIT_CELSIUS,
+        "step": 0.1,
         "message": "TsetCH2",
         "keep_updated": True,
         "message_data": "f88",
@@ -502,6 +505,7 @@ INPUTS: Schema[InputSchema] = Schema({
     "cooling_control": InputSchema({
         "description": "Cooling control signal",
         "unit_of_measurement": UNIT_PERCENT,
+        "step": 1.0,
         "message": "CoolingControl",
         "keep_updated": True,
         "message_data": "f88",
@@ -510,6 +514,7 @@ INPUTS: Schema[InputSchema] = Schema({
     "t_dhw_set": InputSchema({
         "description": "Domestic hot water temperature setpoint",
         "unit_of_measurement": UNIT_CELSIUS,
+        "step": 0.1,
         "message": "TdhwSet",
         "keep_updated": True,
         "message_data": "f88",
@@ -520,6 +525,7 @@ INPUTS: Schema[InputSchema] = Schema({
     "max_t_set": InputSchema({
         "description": "Maximum allowable CH water setpoint",
         "unit_of_measurement": UNIT_CELSIUS,
+        "step": 0.1,
         "message": "MaxTSet",
         "keep_updated": True,
         "message_data": "f88",
@@ -530,6 +536,7 @@ INPUTS: Schema[InputSchema] = Schema({
     "t_room_set": InputSchema({
         "description": "Current room temperature setpoint (informational)",
         "unit_of_measurement": UNIT_CELSIUS,
+        "step": 0.1,
         "message": "TrSet",
         "keep_updated": True,
         "message_data": "f88",
@@ -538,6 +545,7 @@ INPUTS: Schema[InputSchema] = Schema({
     "t_room_set_ch2": InputSchema({
         "description": "Current room temperature setpoint on CH2 (informational)",
         "unit_of_measurement": UNIT_CELSIUS,
+        "step": 0.1,
         "message": "TrSetCH2",
         "keep_updated": True,
         "message_data": "f88",
@@ -546,6 +554,7 @@ INPUTS: Schema[InputSchema] = Schema({
     "t_room": InputSchema({
         "description": "Current sensed room temperature (informational)",
         "unit_of_measurement": UNIT_CELSIUS,
+        "step": 0.1,
         "message": "Tr",
         "keep_updated": True,
         "message_data": "f88",


### PR DESCRIPTION
Fixes #14. According to [this](https://github.com/esphome/aioesphomeapi/pull/393#issuecomment-1484218385), it looks like ESPHome `number` components are required to define a `step` field. I'm not familiar with ESPHome custom components development, so I'm not sure if it was needed to add `step` in so many places.