### PR TITLE
Add master_id option for component config

### DIFF
--- a/components/opentherm/__init__.py
+++ b/components/opentherm/__init__.py
@@ -15,6 +15,7 @@ CONFIG_SCHEMA = cv.All(
         cv.GenerateID(): cv.declare_id(generate.OpenthermHub),
         cv.Optional("in_pin", 4): cv.int_,
         cv.Optional("out_pin", 5): cv.int_,
+        cv.Optional("master_id", 5): cv.int_,
         cv.Optional("ch_enable", True): cv.boolean,
         cv.Optional("dhw_enable", True): cv.boolean,
         cv.Optional("cooling_enable", False): cv.boolean,

--- a/components/opentherm/hub.cpp
+++ b/components/opentherm/hub.cpp
@@ -67,6 +67,10 @@ namespace message_data {
 #define OPENTHERM_IGNORE_2(x, y)
 
 unsigned int OpenthermHub::build_request(OpenThermMessageID request_id) {
+    if (request_id == OpenThermMessageID::MConfigMMemberIDcode) {
+        ESP_LOGD(TAG, "Building Member Config request with id %d", this->master_id);
+        return ot->buildRequest(OpenThermMessageType::WRITE_DATA, OpenThermMessageID::MConfigMMemberIDcode, this->master_id);
+    }
     // First, handle the status request. This requires special logic, because we
     // wouldn't want to inadvertently disable domestic hot water, for example.
     // It is also included in the macro-generated code below, but that will
@@ -225,6 +229,7 @@ void OpenthermHub::setup() {
     this->ot = new OpenTherm(this->in_pin, this->out_pin, false);
     this->ot->begin(this->handle_interrupt_callback, this->process_response_callback);
 
+    this->add_initial_message(OpenThermMessageID::MConfigMMemberIDcode);
     // Ensure that there is at least one request, as we are required to
     // communicate at least once every second. Sending the status request is
     // good practice anyway.

--- a/components/opentherm/hub.h
+++ b/components/opentherm/hub.h
@@ -62,6 +62,8 @@ class OpenthermHub : public Component {
 protected:
     // Communication pins for the OpenTherm interface
     int in_pin, out_pin;
+    // Master id for MConfigMMemberIDcode command
+    int master_id = 0;
     // The OpenTherm interface from @ihormelnyk's library
     OpenTherm* ot;
 
@@ -114,6 +116,7 @@ public:
     // Setters for the input and output OpenTherm interface pins
     void set_in_pin(int in_pin) { this->in_pin = in_pin; }
     void set_out_pin(int out_pin) { this->out_pin = out_pin; }
+    void set_master_id(int master_id) { this->master_id = master_id; }
 
     #define OPENTHERM_SET_SENSOR(entity) void set_ ## entity(sensor::Sensor* sensor) { this->entity = sensor; }
     OPENTHERM_SENSOR_LIST(OPENTHERM_SET_SENSOR, )

--- a/examples/thermostat-pid-complete.yaml
+++ b/examples/thermostat-pid-complete.yaml
@@ -29,6 +29,7 @@ captive_portal:
 opentherm:
   in_pin: 4
   out_pin: 5
+  # master_id: 4 # default 0, baxi 4
   ch_enable: true
   dhw_enable: false
   cooling_enable: false


### PR DESCRIPTION
Some boilers require "right" master id to work properly.
master_id must be provided first before any request with `write_data` command and `MConfigMMemberIDcode`.

Baxi for ex. MMemberIDcode = 4